### PR TITLE
Update themoviedb.js

### DIFF
--- a/lib/themoviedb.js
+++ b/lib/themoviedb.js
@@ -450,7 +450,9 @@ TheMovieDb.prototype.getMovie = function(query, cb) {
                     var releasesObj = _.findWhere(res.body.releases.countries, {
                         primary: true
                     });
-                    movie.rating = releasesObj.certification;
+                    if (releasesObj) {
+                        movie.rating = releasesObj.certification;
+                    }
                 } else {
                     movie.rating = null;
                 }


### PR DESCRIPTION
I encountered the following error while attempting to grab movie details using the getMovie function:

```
TypeError: Cannot read property 'certification' of undefined
    at /Users/foobar/node_modules/themoviedb/lib/themoviedb.js:456:47
    at Request.callback (/Users/foobar/node_modules/superagent/lib/node/index.js:691:12)
    at Stream.<anonymous> (/Users/foobar/node_modules/superagent/lib/node/index.js:922:12)
    at emitNone (events.js:91:20)
    at Stream.emit (events.js:185:7)
    at Unzip.<anonymous> (/Users/foobar/node_modules/superagent/lib/node/utils.js:108:12)
    at emitNone (events.js:91:20)
    at Unzip.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:934:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

The proposed fix is to check that releasesObj has a value before attempting to access its properties.
